### PR TITLE
Release/v 1.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.4
+* Added `pushWidget` API to allow pushing widgets instead of named routes.
+* Extended and simplified logic to retrieve values returned when popping pages awaiting the push
+
 ## 1.1.3
 * Initial GitHub release, updated dependencies. Requires Dart 3.
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: route_manager
 description: A package to manage and simplify routing with Navigator 2.0.
-version: 1.1.3
+version: 1.1.4
 homepage: "https://github.com/mobilesoftcode/route_manager.git"
 issue_tracker: "https://github.com/mobilesoftcode/route_manager/issues"
 


### PR DESCRIPTION
* Added `pushWidget` API to allow pushing widgets instead of named routes.
* Extended and simplified logic to retrieve values returned when popping pages awaiting the push