### PR TITLE
Release/v 2.0.0+2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
+## 2.0.0+2
+Improved previous fix for page popped instead of eventually shown dialog when pressing physical back button on Android, having unintended behaviour on web
+
 ## 2.0.0+1
-* Fixed page popped instead of eventually shown dialog when pressing physical back button on Android 
+Fixed page popped instead of eventually shown dialog when pressing physical back button on Android 
 
 ## 2.0.0
 * Fixed unintended behaviour with urls on web when pushing new pages that replaced entirely the url instead of adding a path segment.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: route_manager
 description: A package to manage and simplify routing with Navigator 2.0.
-version: 2.0.0+1
+version: 2.0.0+2
 homepage: "https://github.com/mobilesoftcode/route_manager.git"
 issue_tracker: "https://github.com/mobilesoftcode/route_manager/issues"
 


### PR DESCRIPTION
Improved previous fix for page popped instead of eventually shown dialog when pressing physical back button on Android, having unintended behaviour on web